### PR TITLE
fixed path variable to not expose sensitive data in the container

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,10 @@
+DATABASE_URL=postgresql://db:5432/myburguer
+DATABASE_USER=myburguer
+DATABASE_PASSWORD=mb
+JWT_KEY=lkjhaskljdajkdlsfjklsdgjklssdljkgff
+WIREMOCK_URL=http://localhost:9090/mercadopago/pagamento
+POSTGRES_USER=myburguer
+POSTGRES_PASSWORD=mb
+POSTGRES_DB=myburguer
+
+LOG_LEVEL=DEBUG

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-DATABASE_URL=postgresql://localhost:5432/myburguer
-DATABASE_USER=myburguer
-DATABASE_PASSWORD=mb
-JWT_KEY=lkjhaskljdajkdlsfjklsdgjklssdljkgff
-
-LOG_LEVEL=DEBUG

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ build/
 .settings
 .springBeans
 .sts4-cache
-.env
+#.env
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ COPY .editorconfig /source/
 
 WORKDIR /source/
 
-RUN cp .env.example .env
 RUN ./gradlew clean build --no-daemon -x test
 
 FROM eclipse-temurin:21-jdk-alpine
@@ -13,7 +12,6 @@ FROM eclipse-temurin:21-jdk-alpine
 EXPOSE 8080
 
 RUN mkdir /app
-RUN env
 
 COPY --from=build /source/build/libs/*.jar /app/spring-boot-application.jar
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: myburguer
-      POSTGRES_PASSWORD: mb
-      POSTGRES_DB: myburguer
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "5432:5432"
     volumes:
@@ -21,10 +21,10 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: "postgresql://db:5432/myburguer"
-      DATABASE_USER: "myburguer"
-      DATABASE_PASSWORD: "mb"
-      JWT_KEY: "lkjhaskljdajkdlsfjklsdgjklssdljkgff"
+      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_USER: ${DATABASE_USER}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+      JWT_KEY: ${JWT_KEY}
       LOG_LEVEL: "DEBUG"
   wiremock:
     image: holomekc/wiremock-gui:3.5.7-alpine


### PR DESCRIPTION
Corrigido as variáveis de ambiente.
Não criei um entrypoint.sh, pois isso não resolveria o problema da exposição das chaves no contêiner.
Acertei o Dockerfile e fiz o rename de .env.example para .env (o docker consome .env automaticamente na build)
Acertei o .gitignore para enviar o .env ao repositório e compartilhar com todos.